### PR TITLE
Convert project to be Carthage compatible.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,3 @@
+github "facebookarchive/ios-snapshot-test-case" ~> 2.1.4
+github "google/EarlGrey" "1.12.1"
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "facebookarchive/ios-snapshot-test-case" "2.1.4"
+github "google/EarlGrey" "1.12.1"

--- a/EarlGreySnapshots.xcodeproj/project.pbxproj
+++ b/EarlGreySnapshots.xcodeproj/project.pbxproj
@@ -1,0 +1,429 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BD89883E200B35070082EA2B /* EarlGrey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE4AC962005940A00F6085F /* EarlGrey.framework */; };
+		BD89883F200B35110082EA2B /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE4AC982005940E00F6085F /* FBSnapshotTestCase.framework */; };
+		BDE4AC842005915200F6085F /* TestNameParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC772005914F00F6085F /* TestNameParser.swift */; };
+		BDE4AC852005915200F6085F /* CurrentTestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC782005914F00F6085F /* CurrentTestObserver.swift */; };
+		BDE4AC862005915200F6085F /* BundleNameProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC792005915000F6085F /* BundleNameProvider.swift */; };
+		BDE4AC872005915200F6085F /* EarlGreySnapshotError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7A2005915000F6085F /* EarlGreySnapshotError.swift */; };
+		BDE4AC882005915200F6085F /* SnapshotAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7B2005915000F6085F /* SnapshotAssertion.swift */; };
+		BDE4AC892005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.h in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7C2005915000F6085F /* XCTestObservationCenter+CurrentTestObserver.h */; };
+		BDE4AC8A2005915200F6085F /* SnapshotControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7D2005915000F6085F /* SnapshotControllerFactory.swift */; };
+		BDE4AC8B2005915200F6085F /* FBSnapshotTestController+Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7E2005915100F6085F /* FBSnapshotTestController+Protocol.swift */; };
+		BDE4AC8C2005915200F6085F /* Bundle+TestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC7F2005915100F6085F /* Bundle+TestBundle.swift */; };
+		BDE4AC8D2005915200F6085F /* SnapshotControllerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC802005915100F6085F /* SnapshotControllerInfo.swift */; };
+		BDE4AC8E2005915200F6085F /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC812005915100F6085F /* Assertions.swift */; };
+		BDE4AC8F2005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC822005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.m */; };
+		BDE4AC902005915200F6085F /* ImagesDirectoryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE4AC832005915200F6085F /* ImagesDirectoryProvider.swift */; };
+		BDE4AC95200591F700F6085F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE4AC94200591F600F6085F /* XCTest.framework */; };
+		BDE4AC9B2005950E00F6085F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE4AC9A2005950E00F6085F /* Foundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BDE4AC6A2005908900F6085F /* EarlGreySnapshots.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EarlGreySnapshots.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BDE4AC6E2005908900F6085F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BDE4AC772005914F00F6085F /* TestNameParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNameParser.swift; sourceTree = "<group>"; };
+		BDE4AC782005914F00F6085F /* CurrentTestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestObserver.swift; sourceTree = "<group>"; };
+		BDE4AC792005915000F6085F /* BundleNameProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleNameProvider.swift; sourceTree = "<group>"; };
+		BDE4AC7A2005915000F6085F /* EarlGreySnapshotError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EarlGreySnapshotError.swift; sourceTree = "<group>"; };
+		BDE4AC7B2005915000F6085F /* SnapshotAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotAssertion.swift; sourceTree = "<group>"; };
+		BDE4AC7C2005915000F6085F /* XCTestObservationCenter+CurrentTestObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestObservationCenter+CurrentTestObserver.h"; sourceTree = "<group>"; };
+		BDE4AC7D2005915000F6085F /* SnapshotControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotControllerFactory.swift; sourceTree = "<group>"; };
+		BDE4AC7E2005915100F6085F /* FBSnapshotTestController+Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FBSnapshotTestController+Protocol.swift"; sourceTree = "<group>"; };
+		BDE4AC7F2005915100F6085F /* Bundle+TestBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+TestBundle.swift"; sourceTree = "<group>"; };
+		BDE4AC802005915100F6085F /* SnapshotControllerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotControllerInfo.swift; sourceTree = "<group>"; };
+		BDE4AC812005915100F6085F /* Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
+		BDE4AC822005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCTestObservationCenter+CurrentTestObserver.m"; sourceTree = "<group>"; };
+		BDE4AC832005915200F6085F /* ImagesDirectoryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesDirectoryProvider.swift; sourceTree = "<group>"; };
+		BDE4AC94200591F600F6085F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		BDE4AC962005940A00F6085F /* EarlGrey.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EarlGrey.framework; path = Carthage/Build/iOS/EarlGrey.framework; sourceTree = "<group>"; };
+		BDE4AC982005940E00F6085F /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSnapshotTestCase.framework; path = Carthage/Build/iOS/FBSnapshotTestCase.framework; sourceTree = "<group>"; };
+		BDE4AC9A2005950E00F6085F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BDE4AC662005908900F6085F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BDE4AC9B2005950E00F6085F /* Foundation.framework in Frameworks */,
+				BDE4AC95200591F700F6085F /* XCTest.framework in Frameworks */,
+				BD89883E200B35070082EA2B /* EarlGrey.framework in Frameworks */,
+				BD89883F200B35110082EA2B /* FBSnapshotTestCase.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BDE4AC602005908900F6085F = {
+			isa = PBXGroup;
+			children = (
+				BDE4AC6C2005908900F6085F /* EarlGreySnapshots */,
+				BDE4AC6B2005908900F6085F /* Products */,
+				BDE4AC93200591F600F6085F /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		BDE4AC6B2005908900F6085F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BDE4AC6A2005908900F6085F /* EarlGreySnapshots.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BDE4AC6C2005908900F6085F /* EarlGreySnapshots */ = {
+			isa = PBXGroup;
+			children = (
+				BDE4AC6E2005908900F6085F /* Info.plist */,
+				BDE4AC922005918500F6085F /* Assets */,
+				BDE4AC912005917500F6085F /* Classes */,
+			);
+			path = EarlGreySnapshots;
+			sourceTree = "<group>";
+		};
+		BDE4AC912005917500F6085F /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				BDE4AC812005915100F6085F /* Assertions.swift */,
+				BDE4AC7F2005915100F6085F /* Bundle+TestBundle.swift */,
+				BDE4AC792005915000F6085F /* BundleNameProvider.swift */,
+				BDE4AC782005914F00F6085F /* CurrentTestObserver.swift */,
+				BDE4AC7A2005915000F6085F /* EarlGreySnapshotError.swift */,
+				BDE4AC7E2005915100F6085F /* FBSnapshotTestController+Protocol.swift */,
+				BDE4AC832005915200F6085F /* ImagesDirectoryProvider.swift */,
+				BDE4AC7B2005915000F6085F /* SnapshotAssertion.swift */,
+				BDE4AC7D2005915000F6085F /* SnapshotControllerFactory.swift */,
+				BDE4AC802005915100F6085F /* SnapshotControllerInfo.swift */,
+				BDE4AC772005914F00F6085F /* TestNameParser.swift */,
+				BDE4AC7C2005915000F6085F /* XCTestObservationCenter+CurrentTestObserver.h */,
+				BDE4AC822005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.m */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		BDE4AC922005918500F6085F /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+		BDE4AC93200591F600F6085F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BDE4AC9A2005950E00F6085F /* Foundation.framework */,
+				BDE4AC982005940E00F6085F /* FBSnapshotTestCase.framework */,
+				BDE4AC962005940A00F6085F /* EarlGrey.framework */,
+				BDE4AC94200591F600F6085F /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BDE4AC672005908900F6085F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BDE4AC692005908900F6085F /* EarlGreySnapshots */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BDE4AC722005908900F6085F /* Build configuration list for PBXNativeTarget "EarlGreySnapshots" */;
+			buildPhases = (
+				BDE4AC652005908900F6085F /* Sources */,
+				BDE4AC662005908900F6085F /* Frameworks */,
+				BDE4AC672005908900F6085F /* Headers */,
+				BDE4AC682005908900F6085F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EarlGreySnapshots;
+			productName = EarlGreySnapshots;
+			productReference = BDE4AC6A2005908900F6085F /* EarlGreySnapshots.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BDE4AC612005908900F6085F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				ORGANIZATIONNAME = "Huy Nguyen";
+				TargetAttributes = {
+					BDE4AC692005908900F6085F = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = BDE4AC642005908900F6085F /* Build configuration list for PBXProject "EarlGreySnapshots" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BDE4AC602005908900F6085F;
+			productRefGroup = BDE4AC6B2005908900F6085F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BDE4AC692005908900F6085F /* EarlGreySnapshots */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BDE4AC682005908900F6085F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BDE4AC652005908900F6085F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BDE4AC842005915200F6085F /* TestNameParser.swift in Sources */,
+				BDE4AC852005915200F6085F /* CurrentTestObserver.swift in Sources */,
+				BDE4AC862005915200F6085F /* BundleNameProvider.swift in Sources */,
+				BDE4AC872005915200F6085F /* EarlGreySnapshotError.swift in Sources */,
+				BDE4AC882005915200F6085F /* SnapshotAssertion.swift in Sources */,
+				BDE4AC892005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.h in Sources */,
+				BDE4AC8A2005915200F6085F /* SnapshotControllerFactory.swift in Sources */,
+				BDE4AC8B2005915200F6085F /* FBSnapshotTestController+Protocol.swift in Sources */,
+				BDE4AC8C2005915200F6085F /* Bundle+TestBundle.swift in Sources */,
+				BDE4AC8D2005915200F6085F /* SnapshotControllerInfo.swift in Sources */,
+				BDE4AC8E2005915200F6085F /* Assertions.swift in Sources */,
+				BDE4AC8F2005915200F6085F /* XCTestObservationCenter+CurrentTestObserver.m in Sources */,
+				BDE4AC902005915200F6085F /* ImagesDirectoryProvider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BDE4AC702005908900F6085F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BDE4AC712005908900F6085F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BDE4AC732005908900F6085F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = EarlGreySnapshots/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = elpassion.EarlGreySnapshots;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BDE4AC742005908900F6085F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = EarlGreySnapshots/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = elpassion.EarlGreySnapshots;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BDE4AC642005908900F6085F /* Build configuration list for PBXProject "EarlGreySnapshots" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BDE4AC702005908900F6085F /* Debug */,
+				BDE4AC712005908900F6085F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BDE4AC722005908900F6085F /* Build configuration list for PBXNativeTarget "EarlGreySnapshots" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BDE4AC732005908900F6085F /* Debug */,
+				BDE4AC742005908900F6085F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BDE4AC612005908900F6085F /* Project object */;
+}

--- a/EarlGreySnapshots.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/EarlGreySnapshots.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:EarlGreySnapshots.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/EarlGreySnapshots.xcodeproj/xcshareddata/xcschemes/EarlGreySnapshots.xcscheme
+++ b/EarlGreySnapshots.xcodeproj/xcshareddata/xcschemes/EarlGreySnapshots.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDE4AC692005908900F6085F"
+               BuildableName = "EarlGreySnapshots.framework"
+               BlueprintName = "EarlGreySnapshots"
+               ReferencedContainer = "container:EarlGreySnapshots.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BDE4AC692005908900F6085F"
+            BuildableName = "EarlGreySnapshots.framework"
+            BlueprintName = "EarlGreySnapshots"
+            ReferencedContainer = "container:EarlGreySnapshots.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BDE4AC692005908900F6085F"
+            BuildableName = "EarlGreySnapshots.framework"
+            BlueprintName = "EarlGreySnapshots"
+            ReferencedContainer = "container:EarlGreySnapshots.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EarlGreySnapshots/EarlGreySnapshots.h
+++ b/EarlGreySnapshots/EarlGreySnapshots.h
@@ -1,0 +1,19 @@
+//
+//  EarlGreySnapshots.h
+//  EarlGreySnapshots
+//
+//  Created by Huy Nguyen on 1/9/18.
+//  Copyright © 2018 Huy Nguyen. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for EarlGreySnapshots.
+FOUNDATION_EXPORT double EarlGreySnapshotsVersionNumber;
+
+//! Project version string for EarlGreySnapshots.
+FOUNDATION_EXPORT const unsigned char EarlGreySnapshotsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <EarlGreySnapshots/PublicHeader.h>
+
+

--- a/EarlGreySnapshots/Info.plist
+++ b/EarlGreySnapshots/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>EarlGreySnapshots</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Example/EarlGreySnapshots.xcodeproj/project.pbxproj
+++ b/Example/EarlGreySnapshots.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		4EB29DFE1F6D04FD009414C1 /* BundleNameProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB29DFD1F6D04FD009414C1 /* BundleNameProviderTests.swift */; };
 		4EB29E011F6D0754009414C1 /* BundleStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB29E001F6D0754009414C1 /* BundleStub.swift */; };
 		4EB29E051F6D1514009414C1 /* Bundle+TestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB29E041F6D1514009414C1 /* Bundle+TestBundle.swift */; };
-		6F892B7C62344DF1D0987194 /* EarlGrey.framework in EarlGrey Copy Files */ = {isa = PBXBuildFile; fileRef = F477714251D07FBC0BB17924 /* EarlGrey.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8CA178C31ECEE90B005C5187 /* TestNameParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA178C21ECEE90B005C5187 /* TestNameParserTests.swift */; };
 		8CA178CC1ECEF1D7005C5187 /* SnapshotActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA178CB1ECEF1D7005C5187 /* SnapshotActionTests.swift */; };
 		8CA178D01ECEF42F005C5187 /* SnapshotControllerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA178CF1ECEF42F005C5187 /* SnapshotControllerFactoryTests.swift */; };
@@ -24,20 +23,6 @@
 		9E4F9AC23E811C202FEEDCBA /* EarlGrey.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F477714251D07FBC0BB17924 /* EarlGrey.framework */; };
 		C9D3067BB5699DDF6162D081 /* EarlGrey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B837D38416539EBAA783427A /* EarlGrey.swift */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		09BECF9085008BB9EE98CBBA /* EarlGrey Copy Files */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "$(TEST_HOST)/../";
-			dstSubfolderSpec = 0;
-			files = (
-				6F892B7C62344DF1D0987194 /* EarlGrey.framework in EarlGrey Copy Files */,
-			);
-			name = "EarlGrey Copy Files";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		312685EDB7169AC8980A968C /* Pods-EarlGreySnapshots_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EarlGreySnapshots_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-EarlGreySnapshots_Tests/Pods-EarlGreySnapshots_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -193,7 +178,6 @@
 				607FACE31AFB9204008FA782 /* Resources */,
 				997AC0FC61DC8002F83BC4B5 /* [CP] Embed Pods Frameworks */,
 				C2B018C706FF70A2DEA0013A /* [CP] Copy Pods Resources */,
-				09BECF9085008BB9EE98CBBA /* EarlGrey Copy Files */,
 			);
 			buildRules = (
 			);

--- a/Example/EarlGreySnapshots_Tests/EarlGrey.swift
+++ b/Example/EarlGreySnapshots_Tests/EarlGrey.swift
@@ -53,8 +53,8 @@ public func GREYAssertEqualObjects<T: Equatable>( _ left: @autoclosure () -> T?,
     " to the object of the right term")
 }
 
-public func GREYAssertNotEqualObjects<T: Equatable>(_ left: @autoclosure () -> T?, right: @autoclosure () -> T?,
-                                                    reason: String) {
+public func GREYAssertNotEqualObjects<T: Equatable>( _ left: @autoclosure () -> T?,
+                                      _ right: @autoclosure () -> T?, reason: String) {
   GREYAssert(left() != right(), reason, details: "Expected object of the left term to not" +
     " equal the object of the right term")
 }
@@ -97,24 +97,24 @@ private func GREYWaitUntilIdle() {
 }
 
 open class EarlGrey: NSObject {
-  open class func select(elementWithMatcher matcher: GREYMatcher,
-                         file: StaticString = #file,
-                         line: UInt = #line) -> GREYElementInteraction {
+  open class func select(elementWithMatcher matcher:GREYMatcher,
+                           file: StaticString = #file,
+                           line: UInt = #line) -> GREYElementInteraction {
     return EarlGreyImpl.invoked(fromFile: file.description, lineNumber: line)
              .selectElement(with: matcher)
   }
 
   open class func setFailureHandler(handler: GREYFailureHandler,
-                                    file: StaticString = #file,
-                                    line: UInt = #line) {
+                                      file: StaticString = #file,
+                                      line: UInt = #line) {
     return EarlGreyImpl.invoked(fromFile: file.description, lineNumber: line)
              .setFailureHandler(handler)
   }
 
   open class func handle(exception: GREYFrameworkException,
-                         details: String,
-                         file: StaticString = #file,
-                         line: UInt = #line) {
+                           details: String,
+                           file: StaticString = #file,
+                           line: UInt = #line) {
     return EarlGreyImpl.invoked(fromFile: file.description, lineNumber: line)
              .handle(exception, details: details)
   }
@@ -136,7 +136,7 @@ extension GREYInteraction {
   }
 
   @discardableResult public func assert(_ matcher: @autoclosure () -> GREYMatcher,
-                                        error: UnsafeMutablePointer<NSError?>!) -> Self {
+                                        error:UnsafeMutablePointer<NSError?>!) -> Self {
     return self.assert(with: matcher(), error: error)
   }
 


### PR DESCRIPTION
Wanted to give a shot at https://github.com/elpassion/EarlGreySnapshots/issues/2. I have given this a quick sanity check in two different projects, but let me know if there are any problems. 

This mostly involved creating a framework project and making it shared. The dependencies are not private as this project depends on both EarlGrey and FBSnapshotTestCase.